### PR TITLE
According to Mondo's docs "settled" is a timestamp not a boolean. Upd…

### DIFF
--- a/mondo_test.go
+++ b/mondo_test.go
@@ -101,7 +101,7 @@ func TestTransactions(t *testing.T) {
 			            "metadata": {},
 			            "notes": "Salmon sandwich 🍞",
 			            "is_load": false,
-			            "settled": true,
+			            "settled": "2015-08-23T12:20:18Z",
 			            "category": "eating_out"
 			        },
 			        {
@@ -132,7 +132,7 @@ func TestTransactions(t *testing.T) {
 			            "metadata": {},
 			            "notes": "",
 			            "is_load": false,
-			            "settled": true,
+			            "settled": "2015-08-23T12:20:18Z",
 			            "category": "eating_out"
 			        }]}
 `)
@@ -196,7 +196,7 @@ func TestTransactionByID(t *testing.T) {
 			            "metadata": {},
 			            "notes": "Salmon sandwich 🍞",
 			            "is_load": false,
-			            "settled": true,
+			            "settled": "2015-08-23T12:20:18Z",
 			            "category": "eating_out"
 			        }}
 `)


### PR DESCRIPTION
…ated sample json with the example value given in docs. Fixes unit tests, because of the wrong settled value they were failing trying to unmarshal a bool into a string.
